### PR TITLE
fixed an issue with MoneyFactory.fromUnits()

### DIFF
--- a/src/main/java/info/javaperformance/money/MoneyFactory.java
+++ b/src/main/java/info/javaperformance/money/MoneyFactory.java
@@ -62,7 +62,7 @@ public class MoneyFactory {
     public static Money fromUnits( final long units, final int precision )
     {
         checkPrecision( precision );
-        return new MoneyLong( units, precision );
+        return new MoneyLong( units, precision ).normalize();
     }
 
     /**


### PR DESCRIPTION
There are some cases like `MoneyFactory.fromUnits(8079, 0)` and `MoneyFactory.fromUnits(80790,1)` that will print different values when the values are actually equal. I'm was working on a `compareTo()` method for `MoneyLong` (ended up being slower for larger precisions). During tests, `MoneyFactory.fromUnits()` failed on that case but the other methods inside of `MoneyFactory` acted appropriately. So my `compareTo()` method couldn't use `fromUnits()` unless the `MoneyLong` was normalized and not printing `8079` and `8079.0` respectively. I reran the tests included in the project after the change and they all passed. `BigDecimal`'s `compareTo()` method doesn't rely on this so perhaps there isn't a need for change. I'm not sure if there are any other situations that normalization is needed.