### PR TITLE
Fixed JavaDoc that prevented compilation due to literal greater than …

### DIFF
--- a/src/main/java/info/javaperformance/money/Money.java
+++ b/src/main/java/info/javaperformance/money/Money.java
@@ -102,7 +102,7 @@ public interface Money extends Comparable<Money> {
 
     /**
      * Truncate the current value leaving no more than {@code maximalPrecision} signs after decimal point.
-     * The number will be rounded towards closest digit (0-4 -> 0; 5-9 -> 1)
+     * The number will be rounded towards closest digit (0-4 -{@literal <} 0; 5-9 -{@literal >} 1)
      * @param maximalPrecision Required precision
      * @return A new Money object normalized to the efficient representation if possible
      */

--- a/src/main/java/info/javaperformance/money/MoneyFactory.java
+++ b/src/main/java/info/javaperformance/money/MoneyFactory.java
@@ -21,7 +21,7 @@ import java.math.BigInteger;
 
 /**
  * Converter from String/double/float/integer types into Money instances.
- * Requires the precision to be specified for double->Money conversion. Precision is usually based
+ * Requires the precision to be specified for double-{@literal >}Money conversion. Precision is usually based
  * on the smallest tick in your exchange data.
  */
 public class MoneyFactory {


### PR DESCRIPTION
mvn clean install failed without this fix.  Here is information on my system.

Apache Maven 3.2.2 (45f7c06d68e745d05611f7fd14efb6594181933e; 2014-06-17T06:51:42-07:00)
Maven home: /opt/maven/current
Java version: 1.8.0_11, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_11.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.9.5", arch: "x86_64", family: "mac"

Are you planning a release anytime soon?
